### PR TITLE
add dmidecode to installed packages

### DIFF
--- a/amazonlinux-2/Dockerfile
+++ b/amazonlinux-2/Dockerfile
@@ -5,6 +5,7 @@ RUN yum -y install \
     ca-certificates \
     cronie \
     curl \
+    dmidecode \
     gnupg2 \
     initscripts \
     iptables \

--- a/amazonlinux/Dockerfile
+++ b/amazonlinux/Dockerfile
@@ -5,6 +5,7 @@ RUN yum -y install \
     ca-certificates \
     cronie \
     curl \
+    dmidecode \
     gnupg2 \
     initscripts \
     iptables \

--- a/centos-6/Dockerfile
+++ b/centos-6/Dockerfile
@@ -5,6 +5,7 @@ RUN yum -y install \
     ca-certificates \
     cronie \
     curl \
+    dmidecode \
     gnupg2 \
     initscripts \
     iptables \

--- a/centos-7/Dockerfile
+++ b/centos-7/Dockerfile
@@ -5,6 +5,7 @@ RUN yum -y install \
     ca-certificates \
     cronie \
     curl \
+    dmidecode \
     gnupg2 \
     initscripts \
     iptables \

--- a/centos-8/Dockerfile
+++ b/centos-8/Dockerfile
@@ -5,6 +5,7 @@ RUN dnf -y install \
     ca-certificates \
     cronie \
     curl \
+    dmidecode \
     gnupg2 \
     initscripts \
     iptables \

--- a/debian-10/Dockerfile
+++ b/debian-10/Dockerfile
@@ -10,6 +10,7 @@ RUN /usr/bin/apt-get update && \
     cron \
     dbus \
     dirmngr \
+    dmidecode \
     gnupg \
     iptables \
     iputils-ping \

--- a/debian-8/Dockerfile
+++ b/debian-8/Dockerfile
@@ -10,6 +10,7 @@ RUN /usr/bin/apt-get update && \
     cron \
     dbus \
     dirmngr \
+    dmidecode \
     gnupg \
     iptables \
     iputils-ping \

--- a/debian-9/Dockerfile
+++ b/debian-9/Dockerfile
@@ -10,6 +10,7 @@ RUN /usr/bin/apt-get update && \
     cron \
     dbus \
     dirmngr \
+    dmidecode \
     gnupg \
     iptables \
     iputils-ping \

--- a/fedora-30/Dockerfile
+++ b/fedora-30/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="sean@sean.io"
 RUN dnf -y install \
     ca-certificates \
     curl \
+    dmidecode \
     gnupg2 \
     hostname \
     initscripts \

--- a/fedora-31/Dockerfile
+++ b/fedora-31/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="sean@sean.io"
 RUN dnf -y install \
     ca-certificates \
     curl \
+    dmidecode \
     gnupg2 \
     hostname \
     initscripts \

--- a/fedora-latest/Dockerfile
+++ b/fedora-latest/Dockerfile
@@ -5,6 +5,7 @@ RUN dnf -y install \
     ca-certificates \
     cronie \
     curl \
+    dmidecode \
     gnupg2 \
     hostname \
     initscripts \

--- a/opensuse-leap-15/Dockerfile
+++ b/opensuse-leap-15/Dockerfile
@@ -7,6 +7,7 @@ RUN zypper update -y && \
                       ca-certificates \
                       curl \
                       cron \
+                      dmidecode \
                       e2fsprogs \
                       file \
                       findutils \

--- a/oraclelinux-6/Dockerfile
+++ b/oraclelinux-6/Dockerfile
@@ -5,6 +5,7 @@ RUN yum -y install \
     ca-certificates \
     cronie \
     curl \
+    dmidecode \
     gnupg2 \
     initscripts \
     iptables \

--- a/oraclelinux-7/Dockerfile
+++ b/oraclelinux-7/Dockerfile
@@ -5,6 +5,7 @@ RUN yum -y install \
     ca-certificates \
     cronie \
     curl \
+    dmidecode \
     gnupg2 \
     initscripts \
     iptables \

--- a/oraclelinux-8/Dockerfile
+++ b/oraclelinux-8/Dockerfile
@@ -5,6 +5,7 @@ RUN dnf -y install \
     ca-certificates \
     cronie \
     curl \
+    dmidecode \
     gnupg2 \
     initscripts \
     iptables \

--- a/ubuntu-16.04/Dockerfile
+++ b/ubuntu-16.04/Dockerfile
@@ -10,6 +10,7 @@ RUN /usr/bin/apt-get update && \
     dbus \
     cron \
     dirmngr \
+    dmidecode \
     gnupg \
     iproute2 \
     iptables \

--- a/ubuntu-18.04/Dockerfile
+++ b/ubuntu-18.04/Dockerfile
@@ -10,6 +10,7 @@ RUN /usr/bin/apt-get update && \
     dbus \
     cron \
     dirmngr \
+    dmidecode \
     gnupg \
     iproute2 \
     iptables \

--- a/ubuntu-19.10/Dockerfile
+++ b/ubuntu-19.10/Dockerfile
@@ -10,6 +10,7 @@ RUN /usr/bin/apt-get update && \
     dbus \
     cron \
     dirmngr \
+    dmidecode \
     gnupg \
     iproute2 \
     iptables \

--- a/ubuntu-20.04/Dockerfile
+++ b/ubuntu-20.04/Dockerfile
@@ -10,6 +10,7 @@ RUN /usr/bin/apt-get update && \
     dbus \
     cron \
     dirmngr \
+    dmidecode \
     gnupg \
     iproute2 \
     iptables \


### PR DESCRIPTION
# Description

The ohai virtualization and shard plugins depend on the ohai dmi plugin, which requires the dmidecode package in order to return data. Since these are default ohai plugins, it would be nice if the dokken images could make the data available.

I'm currently working around this by adding in the platform/package manager specific install logic to the `intermediate_instructions`, like so:
```
      intermediate_instructions:
        # we need dmidecode for the Ohai shard and virtualization plugins
        - RUN dnf install -y dmidecode
```
but it would be nice to just have it in the images
