### PR TITLE
Remove optional systemd services

### DIFF
--- a/amazonlinux-2/Dockerfile
+++ b/amazonlinux-2/Dockerfile
@@ -34,11 +34,15 @@ RUN yum -y install \
     find /etc/systemd/system \
     /lib/systemd/system \
     -path '*.wants/*' \
-    -not -name '*journald*' \
-    -not -name '*systemd-tmpfiles*' \
-    -not -name '*systemd-user-sessions*' \
-    -exec rm \{} \; && \
+    \( -name '*getty*' \
+    -or -name '*postfix*' \
+    -or -name '*systemd-logind*' \
+    -or -name '*systemd-vconsole-setup*' \
+    -or -name '*systemd-readahead*' \
+    -or -name '*systemd-remount-fs*' \
+    -or -name '*udev*' \) \
+    -exec rm -v \{} \; && \
     systemctl set-default multi-user.target && \
-    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/amazonlinux-2/Dockerfile
+++ b/amazonlinux-2/Dockerfile
@@ -29,6 +29,16 @@ RUN yum -y install \
     which && \
     yum clean all && \
     rm -rf /var/cache/yum && \
-    rm -rf /var/log/*
+    rm -rf /var/log/* && \
+    # Don't start any optional services.
+    find /etc/systemd/system \
+    /lib/systemd/system \
+    -path '*.wants/*' \
+    -not -name '*journald*' \
+    -not -name '*systemd-tmpfiles*' \
+    -not -name '*systemd-user-sessions*' \
+    -exec rm \{} \; && \
+    systemctl set-default multi-user.target && \
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/centos-7/Dockerfile
+++ b/centos-7/Dockerfile
@@ -45,6 +45,16 @@ RUN yum -y install \
     which && \
     yum clean all && \
     rm -rf /var/cache/yum && \
-    rm -rf /var/log/*
+    rm -rf /var/log/* && \
+    # Don't start any optional services.
+    find /etc/systemd/system \
+    /lib/systemd/system \
+    -path '*.wants/*' \
+    -not -name '*journald*' \
+    -not -name '*systemd-tmpfiles*' \
+    -not -name '*systemd-user-sessions*' \
+    -exec rm \{} \; && \
+    systemctl set-default multi-user.target && \
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/centos-7/Dockerfile
+++ b/centos-7/Dockerfile
@@ -50,11 +50,13 @@ RUN yum -y install \
     find /etc/systemd/system \
     /lib/systemd/system \
     -path '*.wants/*' \
-    -not -name '*journald*' \
-    -not -name '*systemd-tmpfiles*' \
-    -not -name '*systemd-user-sessions*' \
-    -exec rm \{} \; && \
+    \( -name '*getty*' \
+    -or -name '*systemd-logind*' \
+    -or -name '*systemd-vconsole-setup*' \
+    -or -name '*systemd-readahead*' \
+    -or -name '*udev*' \) \
+    -exec rm -v \{} \; && \
     systemctl set-default multi-user.target && \
-    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/centos-8/Dockerfile
+++ b/centos-8/Dockerfile
@@ -51,11 +51,15 @@ RUN dnf -y install \
     find /etc/systemd/system \
     /lib/systemd/system \
     -path '*.wants/*' \
-    -not -name '*journald*' \
-    -not -name '*systemd-tmpfiles*' \
-    -not -name '*systemd-user-sessions*' \
-    -exec rm \{} \; && \
+    \( -name '*getty*' \
+    -or -name '*systemd-logind*' \
+    -or -name '*systemd-vconsole-setup*' \
+    -or -name '*systemd-readahead*' \
+    -or -name '*kdump*' \
+    -or -name '*dnf-makecache*' \
+    -or -name '*udev*' \) \
+    -exec rm -v \{} \; && \
     systemctl set-default multi-user.target && \
-    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/centos-8/Dockerfile
+++ b/centos-8/Dockerfile
@@ -46,6 +46,16 @@ RUN dnf -y install \
     which && \
     dnf upgrade -y && \
     dnf clean all && \
-    rm -rf /var/log/*
+    rm -rf /var/log/* && \
+    # Don't start any optional services.
+    find /etc/systemd/system \
+    /lib/systemd/system \
+    -path '*.wants/*' \
+    -not -name '*journald*' \
+    -not -name '*systemd-tmpfiles*' \
+    -not -name '*systemd-user-sessions*' \
+    -exec rm \{} \; && \
+    systemctl set-default multi-user.target && \
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/debian-10/Dockerfile
+++ b/debian-10/Dockerfile
@@ -48,6 +48,16 @@ RUN /usr/bin/apt-get update && \
     /usr/bin/apt-get -y autoremove && \
     rm -rf /tmp/* /var/tmp/* && \
     sudo ln -s /bin/mkdir /usr/bin/mkdir && \
-    rm /etc/systemd/system/getty.target.wants/getty\@tty1.service # Remove annoying tty service which consumes 100% CPU
+    # Don't start any optional services.
+    find /etc/systemd/system \
+    /lib/systemd/system \
+    -path '*.wants/*' \
+    -not -name '*journald*' \
+    -not -name '*systemd-tmpfiles*' \
+    -not -name '*systemd-user-sessions*' \
+    -exec rm \{} \; && \
+    systemctl set-default multi-user.target && \
+    systemctl disable exim4.service && \
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
 
 CMD [ "/bin/systemd" ]

--- a/debian-10/Dockerfile
+++ b/debian-10/Dockerfile
@@ -52,12 +52,15 @@ RUN /usr/bin/apt-get update && \
     find /etc/systemd/system \
     /lib/systemd/system \
     -path '*.wants/*' \
-    -not -name '*journald*' \
-    -not -name '*systemd-tmpfiles*' \
-    -not -name '*systemd-user-sessions*' \
-    -exec rm \{} \; && \
+    \( -name '*getty*' \
+    -or -name '*apt-daily*' \
+    -or -name '*systemd-timesyncd*' \
+    -or -name '*systemd-logind*' \
+    -or -name '*systemd-vconsole-setup*' \
+    -or -name '*systemd-readahead*' \
+    -or -name '*udev*' \) \
+    -exec rm -v \{} \; && \
     systemctl set-default multi-user.target && \
-    systemctl disable exim4.service && \
-    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
 
 CMD [ "/bin/systemd" ]

--- a/debian-11/Dockerfile
+++ b/debian-11/Dockerfile
@@ -48,6 +48,16 @@ RUN /usr/bin/apt-get update && \
     /usr/bin/apt-get -y autoremove && \
     rm -rf /tmp/* /var/tmp/* && \
     sudo ln -s /bin/mkdir /usr/bin/mkdir && \
-    rm /etc/systemd/system/getty.target.wants/getty\@tty1.service # Remove annoying tty service which consumes 100% CPU
+    # Don't start any optional services.
+    find /etc/systemd/system \
+    /lib/systemd/system \
+    -path '*.wants/*' \
+    -not -name '*journald*' \
+    -not -name '*systemd-tmpfiles*' \
+    -not -name '*systemd-user-sessions*' \
+    -exec rm \{} \; && \
+    systemctl set-default multi-user.target && \
+    systemctl disable exim4.service && \
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
 
 CMD [ "/bin/systemd" ]

--- a/debian-11/Dockerfile
+++ b/debian-11/Dockerfile
@@ -52,12 +52,15 @@ RUN /usr/bin/apt-get update && \
     find /etc/systemd/system \
     /lib/systemd/system \
     -path '*.wants/*' \
-    -not -name '*journald*' \
-    -not -name '*systemd-tmpfiles*' \
-    -not -name '*systemd-user-sessions*' \
-    -exec rm \{} \; && \
+    \( -name '*getty*' \
+    -or -name '*apt-daily*' \
+    -or -name '*systemd-timesyncd*' \
+    -or -name '*systemd-logind*' \
+    -or -name '*systemd-vconsole-setup*' \
+    -or -name '*systemd-readahead*' \
+    -or -name '*udev*' \) \
+    -exec rm -v \{} \; && \
     systemctl set-default multi-user.target && \
-    systemctl disable exim4.service && \
-    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
 
 CMD [ "/bin/systemd" ]

--- a/debian-9/Dockerfile
+++ b/debian-9/Dockerfile
@@ -47,6 +47,16 @@ RUN /usr/bin/apt-get update && \
     /usr/bin/apt-get -y autoremove && \
     rm -rf /tmp/* /var/tmp/* && \
     sudo ln -s /bin/mkdir /usr/bin/mkdir && \
-    rm /etc/systemd/system/getty.target.wants/getty\@tty1.service # Remove annoying tty service which consumes 100% CPU
+    # Don't start any optional services.
+    find /etc/systemd/system \
+    /lib/systemd/system \
+    -path '*.wants/*' \
+    -not -name '*journald*' \
+    -not -name '*systemd-tmpfiles*' \
+    -not -name '*systemd-user-sessions*' \
+    -exec rm \{} \; && \
+    systemctl set-default multi-user.target && \
+    systemctl disable exim4.service && \
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
 
 CMD [ "/bin/systemd" ]

--- a/debian-9/Dockerfile
+++ b/debian-9/Dockerfile
@@ -51,12 +51,18 @@ RUN /usr/bin/apt-get update && \
     find /etc/systemd/system \
     /lib/systemd/system \
     -path '*.wants/*' \
-    -not -name '*journald*' \
-    -not -name '*systemd-tmpfiles*' \
-    -not -name '*systemd-user-sessions*' \
-    -exec rm \{} \; && \
+    \( -name '*getty*' \
+    -or -name '*apt-daily*' \
+    -or -name '*cgmanager*' \
+    -or -name '*cgproxy*' \
+    -or -name '*systemd-ask-password*' \
+    -or -name '*systemd-logind*' \
+    -or -name '*systemd-readahead*' \
+    -or -name '*systemd-timesyncd*' \
+    -or -name '*systemd-vconsole-setup*' \
+    -or -name '*udev*' \) \
+    -exec rm -v \{} \; && \
     systemctl set-default multi-user.target && \
-    systemctl disable exim4.service && \
-    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
 
 CMD [ "/bin/systemd" ]

--- a/fedora-31/Dockerfile
+++ b/fedora-31/Dockerfile
@@ -44,6 +44,16 @@ RUN dnf -y install \
     libxcrypt-compat \
     which && \
     dnf clean all && \
-    rm -rf /var/log/*
+    rm -rf /var/log/* && \
+    # Don't start any optional services.
+    find /etc/systemd/system \
+    /lib/systemd/system \
+    -path '*.wants/*' \
+    -not -name '*journald*' \
+    -not -name '*systemd-tmpfiles*' \
+    -not -name '*systemd-user-sessions*' \
+    -exec rm \{} \; && \
+    systemctl set-default multi-user.target && \
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/fedora-31/Dockerfile
+++ b/fedora-31/Dockerfile
@@ -49,11 +49,15 @@ RUN dnf -y install \
     find /etc/systemd/system \
     /lib/systemd/system \
     -path '*.wants/*' \
-    -not -name '*journald*' \
-    -not -name '*systemd-tmpfiles*' \
-    -not -name '*systemd-user-sessions*' \
-    -exec rm \{} \; && \
+    \( -name '*getty*' \
+    -or -name '*systemd-logind*' \
+    -or -name '*systemd-vconsole-setup*' \
+    -or -name '*systemd-readahead*' \
+    -or -name '*kdump*' \
+    -or -name '*dnf-makecache*' \
+    -or -name '*udev*' \) \
+    -exec rm -v \{} \; && \
     systemctl set-default multi-user.target && \
-    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/fedora-32/Dockerfile
+++ b/fedora-32/Dockerfile
@@ -45,6 +45,16 @@ RUN dnf -y install \
     libxcrypt-compat \
     which && \
     dnf clean all && \
-    rm -rf /var/log/*
+    rm -rf /var/log/* && \
+    # Don't start any optional services.
+    find /etc/systemd/system \
+    /lib/systemd/system \
+    -path '*.wants/*' \
+    -not -name '*journald*' \
+    -not -name '*systemd-tmpfiles*' \
+    -not -name '*systemd-user-sessions*' \
+    -exec rm \{} \; && \
+    systemctl set-default multi-user.target && \
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/fedora-32/Dockerfile
+++ b/fedora-32/Dockerfile
@@ -50,11 +50,15 @@ RUN dnf -y install \
     find /etc/systemd/system \
     /lib/systemd/system \
     -path '*.wants/*' \
-    -not -name '*journald*' \
-    -not -name '*systemd-tmpfiles*' \
-    -not -name '*systemd-user-sessions*' \
-    -exec rm \{} \; && \
+    \( -name '*getty*' \
+    -or -name '*systemd-logind*' \
+    -or -name '*systemd-vconsole-setup*' \
+    -or -name '*systemd-readahead*' \
+    -or -name '*kdump*' \
+    -or -name '*dnf-makecache*' \
+    -or -name '*udev*' \) \
+    -exec rm -v \{} \; && \
     systemctl set-default multi-user.target && \
-    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/fedora-33/Dockerfile
+++ b/fedora-33/Dockerfile
@@ -45,6 +45,16 @@ RUN dnf -y install \
     libxcrypt-compat \
     which && \
     dnf clean all && \
-    rm -rf /var/log/*
+    rm -rf /var/log/* && \
+    # Don't start any optional services.
+    find /etc/systemd/system \
+    /lib/systemd/system \
+    -path '*.wants/*' \
+    -not -name '*journald*' \
+    -not -name '*systemd-tmpfiles*' \
+    -not -name '*systemd-user-sessions*' \
+    -exec rm \{} \; && \
+    systemctl set-default multi-user.target && \
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/fedora-33/Dockerfile
+++ b/fedora-33/Dockerfile
@@ -50,11 +50,15 @@ RUN dnf -y install \
     find /etc/systemd/system \
     /lib/systemd/system \
     -path '*.wants/*' \
-    -not -name '*journald*' \
-    -not -name '*systemd-tmpfiles*' \
-    -not -name '*systemd-user-sessions*' \
-    -exec rm \{} \; && \
+    \( -name '*getty*' \
+    -or -name '*systemd-logind*' \
+    -or -name '*systemd-vconsole-setup*' \
+    -or -name '*systemd-readahead*' \
+    -or -name '*kdump*' \
+    -or -name '*dnf-makecache*' \
+    -or -name '*udev*' \) \
+    -exec rm -v \{} \; && \
     systemctl set-default multi-user.target && \
-    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/fedora-latest/Dockerfile
+++ b/fedora-latest/Dockerfile
@@ -45,6 +45,16 @@ RUN dnf -y install \
     libxcrypt-compat \
     which && \
     dnf clean all && \
-    rm -rf /var/log/*
+    rm -rf /var/log/* && \
+    # Don't start any optional services.
+    find /etc/systemd/system \
+    /lib/systemd/system \
+    -path '*.wants/*' \
+    -not -name '*journald*' \
+    -not -name '*systemd-tmpfiles*' \
+    -not -name '*systemd-user-sessions*' \
+    -exec rm \{} \; && \
+    systemctl set-default multi-user.target && \
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/fedora-latest/Dockerfile
+++ b/fedora-latest/Dockerfile
@@ -50,11 +50,15 @@ RUN dnf -y install \
     find /etc/systemd/system \
     /lib/systemd/system \
     -path '*.wants/*' \
-    -not -name '*journald*' \
-    -not -name '*systemd-tmpfiles*' \
-    -not -name '*systemd-user-sessions*' \
-    -exec rm \{} \; && \
+    \( -name '*getty*' \
+    -or -name '*systemd-logind*' \
+    -or -name '*systemd-vconsole-setup*' \
+    -or -name '*systemd-readahead*' \
+    -or -name '*kdump*' \
+    -or -name '*dnf-makecache*' \
+    -or -name '*udev*' \) \
+    -exec rm -v \{} \; && \
     systemctl set-default multi-user.target && \
-    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/opensuse-leap-15/Dockerfile
+++ b/opensuse-leap-15/Dockerfile
@@ -45,6 +45,16 @@ RUN zypper update -y && \
                       wget \
                       which && \
     zypper clean && \
-    rm -rf /var/log/*
+    rm -rf /var/log/* && \
+    # Don't start any optional services.
+    find /etc/systemd/system \
+    /usr/lib/systemd/system \
+    -path '*.wants/*' \
+    -not -name '*journald*' \
+    -not -name '*systemd-tmpfiles*' \
+    -not -name '*systemd-user-sessions*' \
+    -exec rm \{} \; && \
+    systemctl set-default multi-user.target && \
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
 
 CMD [ "/bin/systemd" ]

--- a/opensuse-leap-15/Dockerfile
+++ b/opensuse-leap-15/Dockerfile
@@ -50,11 +50,13 @@ RUN zypper update -y && \
     find /etc/systemd/system \
     /usr/lib/systemd/system \
     -path '*.wants/*' \
-    -not -name '*journald*' \
-    -not -name '*systemd-tmpfiles*' \
-    -not -name '*systemd-user-sessions*' \
-    -exec rm \{} \; && \
+    \( -name '*getty*' \
+    -or -name '*systemd-logind*' \
+    -or -name '*systemd-vconsole-setup*' \
+    -or -name '*systemd-readahead*' \
+    -or -name '*udev*' \) \
+    -exec rm -v \{} \; && \
     systemctl set-default multi-user.target && \
-    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
 
 CMD [ "/bin/systemd" ]

--- a/oraclelinux-7/Dockerfile
+++ b/oraclelinux-7/Dockerfile
@@ -44,6 +44,16 @@ RUN yum -y install \
     which && \
     yum clean all && \
     rm -rf /var/cache/yum && \
-    rm -rf /var/log/*
+    rm -rf /var/log/* && \
+    # Don't start any optional services.
+    find /etc/systemd/system \
+    /lib/systemd/system \
+    -path '*.wants/*' \
+    -not -name '*journald*' \
+    -not -name '*systemd-tmpfiles*' \
+    -not -name '*systemd-user-sessions*' \
+    -exec rm \{} \; && \
+    systemctl set-default multi-user.target && \
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/oraclelinux-7/Dockerfile
+++ b/oraclelinux-7/Dockerfile
@@ -49,11 +49,14 @@ RUN yum -y install \
     find /etc/systemd/system \
     /lib/systemd/system \
     -path '*.wants/*' \
-    -not -name '*journald*' \
-    -not -name '*systemd-tmpfiles*' \
-    -not -name '*systemd-user-sessions*' \
-    -exec rm \{} \; && \
+    \( -name '*getty*' \
+    -or -name '*sshd*' \
+    -or -name '*systemd-logind*' \
+    -or -name '*systemd-vconsole-setup*' \
+    -or -name '*systemd-readahead*' \
+    -or -name '*udev*' \) \
+    -exec rm -v \{} \; && \
     systemctl set-default multi-user.target && \
-    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service rhnsd.service
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/oraclelinux-8/Dockerfile
+++ b/oraclelinux-8/Dockerfile
@@ -45,6 +45,16 @@ RUN dnf -y install \
     which && \
     dnf upgrade -y && \
     dnf clean all && \
-    rm -rf /var/log/*
+    rm -rf /var/log/* && \
+    # Don't start any optional services.
+    find /etc/systemd/system \
+    /lib/systemd/system \
+    -path '*.wants/*' \
+    -not -name '*journald*' \
+    -not -name '*systemd-tmpfiles*' \
+    -not -name '*systemd-user-sessions*' \
+    -exec rm \{} \; && \
+    systemctl set-default multi-user.target && \
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/oraclelinux-8/Dockerfile
+++ b/oraclelinux-8/Dockerfile
@@ -50,11 +50,15 @@ RUN dnf -y install \
     find /etc/systemd/system \
     /lib/systemd/system \
     -path '*.wants/*' \
-    -not -name '*journald*' \
-    -not -name '*systemd-tmpfiles*' \
-    -not -name '*systemd-user-sessions*' \
-    -exec rm \{} \; && \
+    \( -name '*getty*' \
+    -or -name '*dnf-makecache*' \
+    -or -name '*sshd*' \
+    -or -name '*systemd-logind*' \
+    -or -name '*systemd-vconsole-setup*' \
+    -or -name '*systemd-readahead*' \
+    -or -name '*udev*' \) \
+    -exec rm -v \{} \; && \
     systemctl set-default multi-user.target && \
-    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/ubuntu-16.04/Dockerfile
+++ b/ubuntu-16.04/Dockerfile
@@ -53,12 +53,15 @@ RUN /usr/bin/apt-get update && \
     find /etc/systemd/system \
     /lib/systemd/system \
     -path '*.wants/*' \
-    -not -name '*journald*' \
-    -not -name '*systemd-tmpfiles*' \
-    -not -name '*systemd-user-sessions*' \
-    -exec rm \{} \; && \
+    \( -name '*getty*' \
+    -or -name '*apt-daily*' \
+    -or -name '*systemd-timesyncd*' \
+    -or -name '*systemd-logind*' \
+    -or -name '*systemd-vconsole-setup*' \
+    -or -name '*systemd-readahead*' \
+    -or -name '*udev*' \) \
+    -exec rm -v \{} \; && \
     systemctl set-default multi-user.target && \
-    systemctl disable ondemand.service apparmor.service && \
-    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
 
 CMD [ "/bin/systemd" ]

--- a/ubuntu-16.04/Dockerfile
+++ b/ubuntu-16.04/Dockerfile
@@ -49,6 +49,16 @@ RUN /usr/bin/apt-get update && \
     /usr/bin/apt-get clean && \
     /usr/bin/apt-get -y autoremove && \
     rm -rf /tmp/* /var/tmp/* && \
-    rm /etc/systemd/system/getty.target.wants/getty\@tty1.service # Remove annoying tty service which consumes 100% CPU
+    # Don't start any optional services.
+    find /etc/systemd/system \
+    /lib/systemd/system \
+    -path '*.wants/*' \
+    -not -name '*journald*' \
+    -not -name '*systemd-tmpfiles*' \
+    -not -name '*systemd-user-sessions*' \
+    -exec rm \{} \; && \
+    systemctl set-default multi-user.target && \
+    systemctl disable ondemand.service apparmor.service && \
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
 
 CMD [ "/bin/systemd" ]

--- a/ubuntu-18.04/Dockerfile
+++ b/ubuntu-18.04/Dockerfile
@@ -53,12 +53,15 @@ RUN /usr/bin/apt-get update && \
     find /etc/systemd/system \
     /lib/systemd/system \
     -path '*.wants/*' \
-    -not -name '*journald*' \
-    -not -name '*systemd-tmpfiles*' \
-    -not -name '*systemd-user-sessions*' \
-    -exec rm \{} \; && \
+    \( -name '*getty*' \
+    -or -name '*apt-daily*' \
+    -or -name '*systemd-timesyncd*' \
+    -or -name '*systemd-logind*' \
+    -or -name '*systemd-vconsole-setup*' \
+    -or -name '*systemd-readahead*' \
+    -or -name '*udev*' \) \
+    -exec rm -v \{} \; && \
     systemctl set-default multi-user.target && \
-    systemctl disable ondemand.service apparmor.service && \
-    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
 
 CMD [ "/bin/systemd" ]

--- a/ubuntu-18.04/Dockerfile
+++ b/ubuntu-18.04/Dockerfile
@@ -49,6 +49,16 @@ RUN /usr/bin/apt-get update && \
     /usr/bin/apt-get -y autoremove && \
     rm -rf /tmp/* /var/tmp/* && \
     sudo ln -s /bin/mkdir /usr/bin/mkdir && \
-    rm /etc/systemd/system/getty.target.wants/getty\@tty1.service # Remove annoying tty service which consumes 100% CPU
+    # Don't start any optional services.
+    find /etc/systemd/system \
+    /lib/systemd/system \
+    -path '*.wants/*' \
+    -not -name '*journald*' \
+    -not -name '*systemd-tmpfiles*' \
+    -not -name '*systemd-user-sessions*' \
+    -exec rm \{} \; && \
+    systemctl set-default multi-user.target && \
+    systemctl disable ondemand.service apparmor.service && \
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
 
 CMD [ "/bin/systemd" ]

--- a/ubuntu-20.04/Dockerfile
+++ b/ubuntu-20.04/Dockerfile
@@ -52,12 +52,15 @@ RUN /usr/bin/apt-get update && \
     find /etc/systemd/system \
     /lib/systemd/system \
     -path '*.wants/*' \
-    -not -name '*journald*' \
-    -not -name '*systemd-tmpfiles*' \
-    -not -name '*systemd-user-sessions*' \
-    -exec rm \{} \; && \
+    \( -name '*getty*' \
+    -or -name '*apt-daily*' \
+    -or -name '*systemd-timesyncd*' \
+    -or -name '*systemd-logind*' \
+    -or -name '*systemd-vconsole-setup*' \
+    -or -name '*systemd-readahead*' \
+    -or -name '*udev*' \) \
+    -exec rm -v \{} \; && \
     systemctl set-default multi-user.target && \
-    systemctl disable ondemand.service apparmor.service && \
-    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
 
 CMD [ "/bin/systemd" ]

--- a/ubuntu-20.04/Dockerfile
+++ b/ubuntu-20.04/Dockerfile
@@ -48,6 +48,16 @@ RUN /usr/bin/apt-get update && \
     /usr/bin/apt-get clean && \
     /usr/bin/apt-get -y autoremove && \
     rm -rf /tmp/* /var/tmp/* && \
-    rm /etc/systemd/system/getty.target.wants/getty\@tty1.service # Remove annoying tty service which consumes 100% CPU
+    # Don't start any optional services.
+    find /etc/systemd/system \
+    /lib/systemd/system \
+    -path '*.wants/*' \
+    -not -name '*journald*' \
+    -not -name '*systemd-tmpfiles*' \
+    -not -name '*systemd-user-sessions*' \
+    -exec rm \{} \; && \
+    systemctl set-default multi-user.target && \
+    systemctl disable ondemand.service apparmor.service && \
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
 
 CMD [ "/bin/systemd" ]

--- a/ubuntu-20.10/Dockerfile
+++ b/ubuntu-20.10/Dockerfile
@@ -52,12 +52,15 @@ RUN /usr/bin/apt-get update && \
     find /etc/systemd/system \
     /lib/systemd/system \
     -path '*.wants/*' \
-    -not -name '*journald*' \
-    -not -name '*systemd-tmpfiles*' \
-    -not -name '*systemd-user-sessions*' \
-    -exec rm \{} \; && \
+    \( -name '*getty*' \
+    -or -name '*apt-daily*' \
+    -or -name '*systemd-timesyncd*' \
+    -or -name '*systemd-logind*' \
+    -or -name '*systemd-vconsole-setup*' \
+    -or -name '*systemd-readahead*' \
+    -or -name '*udev*' \) \
+    -exec rm -v \{} \; && \
     systemctl set-default multi-user.target && \
-    systemctl disable ondemand.service apparmor.service && \
-    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
 
 CMD [ "/bin/systemd" ]

--- a/ubuntu-20.10/Dockerfile
+++ b/ubuntu-20.10/Dockerfile
@@ -48,6 +48,16 @@ RUN /usr/bin/apt-get update && \
     /usr/bin/apt-get clean && \
     /usr/bin/apt-get -y autoremove && \
     rm -rf /tmp/* /var/tmp/* && \
-    rm /etc/systemd/system/getty.target.wants/getty\@tty1.service # Remove annoying tty service which consumes 100% CPU
+    # Don't start any optional services.
+    find /etc/systemd/system \
+    /lib/systemd/system \
+    -path '*.wants/*' \
+    -not -name '*journald*' \
+    -not -name '*systemd-tmpfiles*' \
+    -not -name '*systemd-user-sessions*' \
+    -exec rm \{} \; && \
+    systemctl set-default multi-user.target && \
+    systemctl disable ondemand.service apparmor.service && \
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
 
 CMD [ "/bin/systemd" ]

--- a/ubuntu-21.04/Dockerfile
+++ b/ubuntu-21.04/Dockerfile
@@ -52,12 +52,15 @@ RUN /usr/bin/apt-get update && \
     find /etc/systemd/system \
     /lib/systemd/system \
     -path '*.wants/*' \
-    -not -name '*journald*' \
-    -not -name '*systemd-tmpfiles*' \
-    -not -name '*systemd-user-sessions*' \
-    -exec rm \{} \; && \
+    \( -name '*getty*' \
+    -or -name '*apt-daily*' \
+    -or -name '*systemd-timesyncd*' \
+    -or -name '*systemd-logind*' \
+    -or -name '*systemd-vconsole-setup*' \
+    -or -name '*systemd-readahead*' \
+    -or -name '*udev*' \) \
+    -exec rm -v \{} \; && \
     systemctl set-default multi-user.target && \
-    systemctl disable ondemand.service apparmor.service && \
-    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
 
 CMD [ "/bin/systemd" ]

--- a/ubuntu-21.04/Dockerfile
+++ b/ubuntu-21.04/Dockerfile
@@ -48,6 +48,16 @@ RUN /usr/bin/apt-get update && \
     /usr/bin/apt-get clean && \
     /usr/bin/apt-get -y autoremove && \
     rm -rf /tmp/* /var/tmp/* && \
-    rm /etc/systemd/system/getty.target.wants/getty\@tty1.service # Remove annoying tty service which consumes 100% CPU
+    # Don't start any optional services.
+    find /etc/systemd/system \
+    /lib/systemd/system \
+    -path '*.wants/*' \
+    -not -name '*journald*' \
+    -not -name '*systemd-tmpfiles*' \
+    -not -name '*systemd-user-sessions*' \
+    -exec rm \{} \; && \
+    systemctl set-default multi-user.target && \
+    systemctl disable ondemand.service apparmor.service && \
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount
 
 CMD [ "/bin/systemd" ]


### PR DESCRIPTION
This removes all the unnecessary services that are enabled by default and are not needed for running inside of containers. The only service that should be running is journald.

This also seems to fix issues noticed running these images on Linux based systems where the system either pauses for a few seconds while the container is "booting" or experience logout issues.

In addition, this also speeds up container "booting" since it only needs to run journald on start up.

Some other notes:

- Disable exim service on Debian
- Disable ondemand and apparmor services on Ubuntu

Signed-off-by: Lance Albertson <lance@osuosl.org>
