### PR TITLE
Update opensuse leap to 15.3

### DIFF
--- a/opensuse-leap-15/Dockerfile
+++ b/opensuse-leap-15/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/leap:15.2
+FROM opensuse/leap:15
 LABEL maintainer="sean@sean.io"
 ARG BUILD_DATE
 ARG VCS_REF


### PR DESCRIPTION
Let it float on the most recent 15

Signed-off-by: Tim Smith <tsmith@chef.io>