### PR TITLE
Fix the AlmaLinux image to work on M1/arm

### DIFF
--- a/almalinux-8/Dockerfile
+++ b/almalinux-8/Dockerfile
@@ -1,4 +1,4 @@
-FROM almalinux/almalinux:8
+FROM almalinux:8
 LABEL maintainer="tsmith84@gmail.com"
 ARG BUILD_DATE
 ARG VCS_REF


### PR DESCRIPTION
Build from the right upstream image so we get an arm base as well.

Signed-off-by: Tim Smith <tsmith84@gmail.com>