### PR TITLE
Upgrade all packages on EL 6/7 platforms

### DIFF
--- a/centos-6/Dockerfile
+++ b/centos-6/Dockerfile
@@ -40,6 +40,7 @@ RUN yum -y install \
     vim-minimal \
     wget \
     which && \
+    yum upgrade -y && \
     yum clean all && \
     rm -rf /var/cache/yum && \
     rm -rf /var/log/*

--- a/centos-7/Dockerfile
+++ b/centos-7/Dockerfile
@@ -44,6 +44,7 @@ RUN yum -y install \
     vim-minimal \
     wget \
     which && \
+    yum upgrade -y && \
     yum clean all && \
     rm -rf /var/cache/yum && \
     rm -rf /var/log/* && \

--- a/oraclelinux-6/Dockerfile
+++ b/oraclelinux-6/Dockerfile
@@ -27,6 +27,7 @@ RUN yum -y install \
     vim-minimal \
     wget \
     which && \
+    yum upgrade -y && \
     yum clean all && \
     rm -rf /var/cache/yum && \
     rm -rf /var/log/*

--- a/oraclelinux-7/Dockerfile
+++ b/oraclelinux-7/Dockerfile
@@ -43,6 +43,7 @@ RUN yum -y install \
     vim-minimal \
     wget \
     which && \
+    yum upgrade -y && \
     yum clean all && \
     rm -rf /var/cache/yum && \
     rm -rf /var/log/* && \


### PR DESCRIPTION
I'm not sure why we weren't doing this, but this way you get more
patched systems. CentOS pushes container images a lot, but Oracle does
not.

Signed-off-by: Tim Smith <tsmith84@gmail.com>