### PR TITLE
Add libxcrypt-compat to centos stream 9 to work around chef bug

### DIFF
--- a/centos-stream-9/Dockerfile
+++ b/centos-stream-9/Dockerfile
@@ -46,6 +46,7 @@ RUN dnf --allowerasing -y install \
     util-linux \
     vim-minimal \
     wget \
+    libxcrypt-compat \
     which && \
     dnf upgrade -y && \
     dnf clean all && \


### PR DESCRIPTION
# Description

CentOS 9 has the same bug as Fedora/Alma 9/Rocky 9 with a missing `libcrypto.so.1` library.

## Issues Resolved

- n/a

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
