### PR TITLE
Install libxcrypt-compat on oraclelinux-9

### DIFF
--- a/oraclelinux-9/Dockerfile
+++ b/oraclelinux-9/Dockerfile
@@ -57,6 +57,7 @@ RUN dnf -y install \
 	vim-minimal \
 	time \
 	wget \
+	libxcrypt-compat \
 	which && \
 	dnf upgrade -y && \
 	dnf clean all && \

--- a/rockylinux-9/Dockerfile
+++ b/rockylinux-9/Dockerfile
@@ -12,7 +12,7 @@ LABEL org.label-schema.vcs-ref=$VCS_REF
 LABEL org.label-schema.vendor="test-kitchen"
 
 # hadolint ignore=DL3041
-RUN dnf -y install \
+RUN dnf --allowerasing -y install \
 	at \
 	binutils \
 	bc \


### PR DESCRIPTION
This will allow for older versions of Chef to be testable. This replicates what's been done on other RHEL-clones as well.

Signed-off-by: Lance Albertson <lance@osuosl.org>
