### PR TITLE
Mask systemd-journal-flush.service on RHEL >=8 & Fedora

### DIFF
--- a/almalinux-8/Dockerfile
+++ b/almalinux-8/Dockerfile
@@ -62,6 +62,6 @@ RUN dnf -y install \
 	-or -name '*udev*' \) \
 	-exec rm -v {} \; && \
 	systemctl set-default multi-user.target && \
-	systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
+	systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service systemd-journal-flush.service
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/almalinux-9/Dockerfile
+++ b/almalinux-9/Dockerfile
@@ -73,6 +73,6 @@ RUN dnf -y install \
     -or -name '*udev*' \) \
     -exec rm -v \{} \; && \
     systemctl set-default multi-user.target && \
-    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
+    systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service systemd-journal-flush.service
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/centos-stream-8/Dockerfile
+++ b/centos-stream-8/Dockerfile
@@ -62,6 +62,6 @@ RUN dnf -y install \
   -or -name '*udev*' \) \
   -exec rm -v {} \; && \
   systemctl set-default multi-user.target && \
-  systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
+  systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service systemd-journal-flush.service
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/centos-stream-9/Dockerfile
+++ b/centos-stream-9/Dockerfile
@@ -62,6 +62,6 @@ RUN dnf --allowerasing -y install \
 	-or -name '*udev*' \) \
 	-exec rm -v {} \; && \
 	systemctl set-default multi-user.target && \
-	systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
+	systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service systemd-journal-flush.service
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/fedora-36/Dockerfile
+++ b/fedora-36/Dockerfile
@@ -62,6 +62,6 @@ RUN dnf -y install \
   -or -name '*udev*' \) \
   -exec rm -v {} \; && \
   systemctl set-default multi-user.target && \
-  systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
+  systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service systemd-journal-flush.service
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/fedora-37/Dockerfile
+++ b/fedora-37/Dockerfile
@@ -62,6 +62,6 @@ RUN dnf -y install \
   -or -name '*udev*' \) \
   -exec rm -v {} \; && \
   systemctl set-default multi-user.target && \
-  systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
+  systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service systemd-journal-flush.service
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/fedora-38/Dockerfile
+++ b/fedora-38/Dockerfile
@@ -62,6 +62,6 @@ RUN dnf -y install \
 	-or -name '*udev*' \) \
 	-exec rm -v {} \; && \
 	systemctl set-default multi-user.target && \
-	systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
+	systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service systemd-journal-flush.service
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/fedora-latest/Dockerfile
+++ b/fedora-latest/Dockerfile
@@ -61,6 +61,6 @@ RUN dnf -y install \
   -or -name '*udev*' \) \
   -exec rm -v {} \; && \
   systemctl set-default multi-user.target && \
-  systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
+  systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service systemd-journal-flush.service
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/oraclelinux-8/Dockerfile
+++ b/oraclelinux-8/Dockerfile
@@ -60,6 +60,6 @@ RUN dnf -y install \
 	-or -name '*udev*' \) \
 	-exec rm -v {} \; && \
 	systemctl set-default multi-user.target && \
-	systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
+	systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service systemd-journal-flush.service
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/oraclelinux-9/Dockerfile
+++ b/oraclelinux-9/Dockerfile
@@ -75,6 +75,6 @@ RUN dnf -y install \
 	-or -name '*udev*' \) \
 	-exec rm -v {} \; && \
 	systemctl set-default multi-user.target && \
-	systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
+	systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service systemd-journal-flush.service
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/rockylinux-8/Dockerfile
+++ b/rockylinux-8/Dockerfile
@@ -62,6 +62,6 @@ RUN dnf -y install \
 	-or -name '*udev*' \) \
 	-exec rm -v {} \; && \
 	systemctl set-default multi-user.target && \
-	systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
+	systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service systemd-journal-flush.service
 
 CMD [ "/usr/lib/systemd/systemd" ]

--- a/rockylinux-9/Dockerfile
+++ b/rockylinux-9/Dockerfile
@@ -74,6 +74,6 @@ RUN dnf --allowerasing -y install \
 	-or -name '*udev*' \) \
 	-exec rm -v {} \; && \
 	systemctl set-default multi-user.target && \
-	systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
+	systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service systemd-journal-flush.service
 
 CMD [ "/usr/lib/systemd/systemd" ]


### PR DESCRIPTION
We started running into issues similar to the following [1] where running yum commands would fail and were similar to the problems mentioned here [2]. Afterdoing some digging, I noticed that systemctl status was still initializating on the centos-stream-8 image and it was due to the systemd-journal-flush.service service.

We shouldn't need this for dokken so let's just mask this for any RHEL-based system 8 or newer along with all Fedora. I'm not sure if this is going to be needed elsewhere but this is a start.

[1] https://github.com/sous-chefs/yum/actions/runs/4452618323/jobs/7820436622?pr=206#step:4:222
[2] https://www.jeffgeerling.com/blog/2020/resolving-fedora-dnf-error-no-such-file-or-directory-varlibdnfrpmdblockpid

Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Please describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
