### PR TITLE
fix: add python to debian 12

### DIFF
--- a/debian-12/Dockerfile
+++ b/debian-12/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update && \
 	net-tools \
 	nmap \
 	perl \
+	python-is-python3 \
 	procps \
 	strace \
 	sudo \


### PR DESCRIPTION
# Description

Adds python to debian 12 which is currently missing, the debian 10 and 11 images contained python which was pulled in as a dependency for lsb_release but it turns out lsb_release doesn't depend on python in debian 12.
Also most of the container images here already contain python, or at least the ones I use (almalinux/centos/fedora/ubuntu).