### PR TITLE
_fix_ Use correct /usr/lib/systemd/systemd on debian-13

### DIFF
--- a/debian-13/Dockerfile
+++ b/debian-13/Dockerfile
@@ -54,6 +54,7 @@ RUN apt-get update && \
 	-path '*.wants/*' \
 	\( -name '*getty*' \
 	-or -name '*apt-daily*' \
+	-or -name '*dpkg-db-backup*' \
 	-or -name '*systemd-timesyncd*' \
 	-or -name '*systemd-logind*' \
 	-or -name '*systemd-vconsole-setup*' \
@@ -61,6 +62,6 @@ RUN apt-get update && \
 	-or -name '*udev*' \) \
 	-exec rm -v {} \; && \
 	systemctl set-default multi-user.target && \
-	systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
+	systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service systemd-journal-flush.service
 
-CMD [ "/bin/systemd" ]
+CMD [ "/usr/lib/systemd/systemd" ]


### PR DESCRIPTION
# Description

Fix docker cmd to use correct systemd binary. Remove systemd `dpkg-db-backup` service/timer  and disable `systemd-journal-flush.service`

## Issues Resolved

* Use correct container CMD: /usr/lib/systemd/systemd
* Remove unneeded dpkg-db-backup service/timer 
* Disable unneeded systemd-journal-flush.service

## Type of Change

_fix_

## Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
