### PR TITLE
fix: clean up some legacy Debian constructs

### DIFF
--- a/debian-11/Dockerfile
+++ b/debian-11/Dockerfile
@@ -16,7 +16,6 @@ ENV DEBIAN_FRONTEND noninteractive
 # hadolint ignore=DL3041
 RUN /usr/bin/apt-get update && \
   /usr/bin/apt-get -y install \
-  apt-transport-https \
   apt-utils \
   cron \
   curl \

--- a/debian-12/Dockerfile
+++ b/debian-12/Dockerfile
@@ -16,7 +16,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 # hadolint ignore=DL3041
 RUN apt-get update && \
 	apt-get -y install \
-	apt-transport-https \
 	apt-utils \
 	cron \
 	curl \
@@ -49,7 +48,6 @@ RUN apt-get update && \
 	apt-get clean && \
 	apt-get -y autoremove && \
 	rm -rf /tmp/* /var/tmp/* && \
-	ln -s /bin/mkdir mkdir && \
 	find /etc/systemd/system \
 	/lib/systemd/system \
 	-path '*.wants/*' \

--- a/debian-13/Dockerfile
+++ b/debian-13/Dockerfile
@@ -14,9 +14,7 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 ENV DEBIAN_FRONTEND=noninteractive
 
 # hadolint ignore=DL3041
-RUN apt-get update && \
-	apt-get -y install \
-	apt-transport-https \
+RUN apt-get -y --update install \
 	apt-utils \
 	cron \
 	curl \
@@ -48,7 +46,6 @@ RUN apt-get update && \
 	apt-get clean && \
 	apt-get -y autoremove && \
 	rm -rf /tmp/* /var/tmp/* && \
-	ln -s /bin/mkdir mkdir && \
 	find /etc/systemd/system \
 	/lib/systemd/system \
 	-path '*.wants/*' \

--- a/debian-14/Dockerfile
+++ b/debian-14/Dockerfile
@@ -14,9 +14,7 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 ENV DEBIAN_FRONTEND=noninteractive
 
 # hadolint ignore=DL3041
-RUN apt-get update && \
-	apt-get -y install \
-	apt-transport-https \
+RUN apt-get -y --update install \
 	apt-utils \
 	cron \
 	curl \
@@ -48,7 +46,6 @@ RUN apt-get update && \
 	apt-get clean && \
 	apt-get -y autoremove && \
 	rm -rf /tmp/* /var/tmp/* && \
-	ln -s /bin/mkdir mkdir && \
 	find /etc/systemd/system \
 	/lib/systemd/system \
 	-path '*.wants/*' \

--- a/ubuntu-18.04/Dockerfile
+++ b/ubuntu-18.04/Dockerfile
@@ -16,7 +16,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 # hadolint ignore=DL3008,DL3015,DL3004
 RUN apt-get update && \
 	apt-get -y install \
-	apt-transport-https \
 	apt-utils \
 	curl \
 	dbus \

--- a/ubuntu-20.04/Dockerfile
+++ b/ubuntu-20.04/Dockerfile
@@ -16,7 +16,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 # hadolint ignore=DL3008,DL3015
 RUN apt-get update && \
 	apt-get -y install \
-	apt-transport-https \
 	apt-utils \
 	curl \
 	dbus \

--- a/ubuntu-22.04/Dockerfile
+++ b/ubuntu-22.04/Dockerfile
@@ -16,7 +16,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 # hadolint ignore=DL3008,DL3015
 RUN apt-get update && \
 	apt-get -y install \
-	apt-transport-https \
 	apt-utils \
 	curl \
 	dbus \
@@ -65,4 +64,4 @@ RUN apt-get update && \
 	systemctl set-default multi-user.target && \
 	systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
 
-CMD [ "/bin/systemd" ]
+CMD [ "/usr/lib/systemd/systemd" ]

--- a/ubuntu-24.04/Dockerfile
+++ b/ubuntu-24.04/Dockerfile
@@ -14,9 +14,7 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 ENV DEBIAN_FRONTEND=noninteractive
 
 # hadolint ignore=DL3008,DL3015
-RUN apt-get update && \
-	apt-get -y install \
-	apt-transport-https \
+RUN apt-get -y --update install \
 	apt-utils \
 	curl \
 	dbus \
@@ -64,4 +62,4 @@ RUN apt-get update && \
 	systemctl set-default multi-user.target && \
 	systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
 
-CMD [ "/bin/systemd" ]
+CMD [ "/usr/lib/systemd/systemd" ]

--- a/ubuntu-25.04/Dockerfile
+++ b/ubuntu-25.04/Dockerfile
@@ -14,9 +14,7 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 ENV DEBIAN_FRONTEND=noninteractive
 
 # hadolint ignore=DL3008,DL3015
-RUN apt-get update && \
-	apt-get -y install \
-	apt-transport-https \
+RUN apt-get -y --update install \
 	apt-utils \
 	curl \
 	dbus \
@@ -64,4 +62,4 @@ RUN apt-get update && \
 	systemctl set-default multi-user.target && \
 	systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
 
-CMD [ "/bin/systemd" ]
+CMD [ "/usr/lib/systemd/systemd" ]

--- a/ubuntu-25.10/Dockerfile
+++ b/ubuntu-25.10/Dockerfile
@@ -14,9 +14,7 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 ENV DEBIAN_FRONTEND=noninteractive
 
 # hadolint ignore=DL3008,DL3015
-RUN apt-get update && \
-	apt-get -y install \
-	apt-transport-https \
+RUN apt-get -y --update install \
 	apt-utils \
 	curl \
 	dbus \
@@ -64,4 +62,4 @@ RUN apt-get update && \
 	systemctl set-default multi-user.target && \
 	systemctl mask dev-hugepages.mount sys-fs-fuse-connections.mount network.service
 
-CMD [ "/bin/systemd" ]
+CMD [ "/usr/lib/systemd/systemd" ]


### PR DESCRIPTION

- Combine apt update/install on modern Debian/Ubuntu versions
- apt-transport-https has been an empty package since ~2018
- Use systemd from lib instead of bin
- Remove useless mkdir workaround on usr-merged systems

