### PR TITLE
fix: Setup Python in Debian consistently

### DIFF
--- a/debian-11/Dockerfile
+++ b/debian-11/Dockerfile
@@ -36,6 +36,8 @@ RUN /usr/bin/apt-get update && \
   netcat \
   nmap \
   perl \
+  python3 \
+  python-is-python3 \
   procps \
   strace \
   sudo \

--- a/debian-12/Dockerfile
+++ b/debian-12/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update && \
 	net-tools \
 	nmap \
 	perl \
+	python3 \
 	python-is-python3 \
 	procps \
 	strace \

--- a/debian-13/Dockerfile
+++ b/debian-13/Dockerfile
@@ -35,6 +35,8 @@ RUN apt-get update && \
 	net-tools \
 	nmap \
 	perl \
+	python3 \
+	python-is-python3 \
 	procps \
 	strace \
 	sudo \

--- a/debian-14/Dockerfile
+++ b/debian-14/Dockerfile
@@ -35,6 +35,8 @@ RUN apt-get update && \
 	net-tools \
 	nmap \
 	perl \
+	python3 \
+	python-is-python3 \
 	procps \
 	strace \
 	sudo \


### PR DESCRIPTION

# Description

Be explicit about including Python in Debian containers so that it's consistent across all releases.

## Issues Resolved

Python is missing from Debian 13/14.

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
